### PR TITLE
Applied fix from trunk for revision: 1860797

### DIFF
--- a/applications/marketing/webapp/sfa/WEB-INF/controller.xml
+++ b/applications/marketing/webapp/sfa/WEB-INF/controller.xml
@@ -220,6 +220,7 @@ under the License.
         <event type="service" invoke="createContact"/>
         <response name="success" type="request-redirect" value="viewprofile">
             <redirect-parameter name="partyId"/>
+            <redirect-parameter name="roleTypeId"/>
         </response>
     </request-map>
 


### PR DESCRIPTION
===

Fixed: Profile of contact person not shown on quick add of contact in SFA.
(OFBIZ-7816)
Issue occurred due to missing redirect parameter.
Thanks Rohit Hukkeri for providing the updated patch and everyone else for their contribution in this ticket.


git-svn-id: https://svn.apache.org/repos/asf/ofbiz/ofbiz-framework/branches/release18.12@1860798 13f79535-47bb-0310-9956-ffa450edef68